### PR TITLE
Copy the existing channel info for newer channel service versions

### DIFF
--- a/MythUtil-Channel-XMLTV-getLineup
+++ b/MythUtil-Channel-XMLTV-getLineup
@@ -393,7 +393,7 @@ if __name__ == '__main__':
                 break
         if found and ((args.noReport is None) or ('changed' not in args.noReport)):
             update = False
-            if ChannelServiceVersion < versionTuple("1.9"):
+            if ChannelServiceVersion == versionTuple("1.9"):
                 data = {}
                 data['ChanId'] = mythChannel['ChanId']
             else:

--- a/MythUtil-Channel-XMLTV-getLineup
+++ b/MythUtil-Channel-XMLTV-getLineup
@@ -30,7 +30,7 @@ class MythTVServices():
             self.request(service='Myth', api='version')
 
     def request(self, service=None, api=None, data={}, method=None, stream=False):
-        version = '0.28'
+        version = '0.34'
         headers = {'User-Agent':'{} Python Services API Client'.format(version),
                    'Accept':'application/json',
                    'Accept-Encoding':'gzip,deflate'}
@@ -393,7 +393,7 @@ if __name__ == '__main__':
                 break
         if found and ((args.noReport is None) or ('changed' not in args.noReport)):
             update = False
-            if ChannelServiceVersion >= versionTuple("1.9"):
+            if ChannelServiceVersion < versionTuple("1.9"):
                 data = {}
                 data['ChanId'] = mythChannel['ChanId']
             else:


### PR DESCRIPTION
Copy the existing channel info for newer channel service versions.

As per: https://www.mythtv.org/wiki/Channel_Service#UpdateDBChannel

> Missing values may take unintended default values.

And I found when opting not to update these (with `--no-update-*`) resulted in these changing to defaults, rather than left the same.

Draft as I couldn't work out if it was the channel service version comparison being inverted, or if this should be for all versions.

*edit*

Right - so it's actually a reversion of https://github.com/garybuhrmaster/MythUtil/commit/95e52019cc1b0122b15e396294680d7ae05c6f9a